### PR TITLE
Remove outdated scrape_once cell

### DIFF
--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -363,24 +363,6 @@
   {
    "cell_type": "code",
    "source": [
-    "async def scrape_once():\n",
-    "  await client.start(phone=PHONE)\n",
-    "  last_seen=load_progress();append_header_if_needed()\n",
-    "  for c in CHANNELS:\n",
-    "    sid=last_seen.get(c,0)\n",
-    "    new_id=await scrape_channel(c,sid)\n",
-    "    last_seen[c]=new_id\n",
-    "  save_progress(last_seen);await client.disconnect()\n"
-   ],
-   "metadata": {
-    "id": "w7JNJcbwE_EY"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
     "def run_scrape():\n",
     "  asyncio.run(scrape_once())\n",
     "  print(\"Scraping done.\")\n"


### PR DESCRIPTION
## Summary
- remove duplicate early scrape_once cell in the notebook

## Testing
- `pytest -q` *(fails: command not found)*