### PR TITLE
Load env vars in notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Telegram-research
+
+This project requires the following environment variables before running the notebook:
+- API_ID
+- API_HASH
+- PHONE

--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -115,13 +115,13 @@
    "cell_type": "code",
    "source": [
     "import os, json, csv, time, re\n",
-    "import csv, json\n",
     "import asyncio, requests, pandas as pd\n",
     "from pathlib import Path\n",
     "from dotenv import load_dotenv\n",
     "from urllib.parse import urlparse\n",
     "from langdetect import detect, DetectorFactory\n",
-    "DetectorFactory.seed=0"
+    "DetectorFactory.seed=0",
+    "load_dotenv()\n"
    ],
    "metadata": {
     "id": "Cf2Q2pXXC4ZM"
@@ -133,8 +133,7 @@
    "cell_type": "code",
    "source": [
     "from telethon import TelegramClient, errors\n",
-    "from telethon.tl.functions.channels import JoinChannelRequest\n",
-    "from telethon.tl.types import PeerChannel"
+    "from telethon.tl.functions.channels import JoinChannelRequest\n"
    ],
    "metadata": {
     "id": "oGRmc41x_UlG"
@@ -157,9 +156,10 @@
   {
    "cell_type": "code",
    "source": [
-    "from telethon import TelegramClient, errors\n",
-    "from telethon.tl.functions.channels import JoinChannelRequest\n",
-    "API_ID=24527187;API_HASH='8a012769064c0218d779c9e23e45fdb0';PHONE='+18573343025'\n"
+    "# expects API_ID, API_HASH, and PHONE in the environment\n",
+    "API_ID = os.getenv(\"API_ID\")\n",
+    "API_HASH = os.getenv(\"API_HASH\")\n",
+    "PHONE = os.getenv(\"PHONE\")\n"
    ],
    "metadata": {
     "id": "_MchyQTGC8IQ"


### PR DESCRIPTION
## Summary
- document required environment variables for Telethon credentials
- load dotenv configuration early in the notebook
- read API_ID, API_HASH, and PHONE from the environment
- clean up duplicate imports left by merge conflict

## Testing
- `grep -n load_dotenv\(\) -n 'Telegram (5).ipynb'`
