### PR TITLE
Add env var validation in notebook

### DIFF
--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -159,8 +159,10 @@
     "# expects API_ID, API_HASH, and PHONE in the environment\n",
     "API_ID = os.getenv(\"API_ID\")\n",
     "API_HASH = os.getenv(\"API_HASH\")\n",
-    "PHONE = os.getenv(\"PHONE\")\n"
-   ],
+    "PHONE = os.getenv(\"PHONE\")\n",
+    "if not all([API_ID, API_HASH, PHONE]):\n",
+    "    raise RuntimeError(\"API_ID, API_HASH and PHONE environment variables must be set\")\n"
+  ],
    "metadata": {
     "id": "_MchyQTGC8IQ"
    },


### PR DESCRIPTION
## Summary
- raise an error in the notebook if required credentials are missing

## Testing
- `API_ID=1 API_HASH=2 PHONE=3 TS_SKIP_DATASET=1 python -m unittest discover tests`