### PR TITLE
Read path constants from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Optional variables allow customization of paths and crawling limits:
 - `CLEAN_CSV` – cleaned output file (default `cleaned.csv`)
 - `BFS_HOPS`, `BFS_PER_CH_LIMIT`, `BFS_MIN_SUBS`, `BFS_LANG_SAMPLE`, `BFS_EN_RATIO` – parameters for channel discovery
 
+These path variables are optional; if unset the defaults shown above are used.
+
 The dataset of suspicious channels was manually curated and contains usernames and subscriber counts for various crypto signal groups.
 
 ## Usage

--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -261,10 +261,10 @@
   {
    "cell_type": "code",
    "source": [
-    "PROGRESS_JSON='/content/drive/MyDrive/telegram/progress.json'\n",
-    "RAW_CSV='/content/drive/MyDrive/telegram/messages.csv'\n",
-    "CLEAN_CSV='/content/drive/MyDrive/telegram/cleaned.csv'\n",
-    "SESSION_NAME='tg_session'"
+    "PROGRESS_JSON = os.getenv('PROGRESS_JSON', '/content/drive/MyDrive/telegram/progress.json')\n",
+    "RAW_CSV = os.getenv('RAW_CSV', '/content/drive/MyDrive/telegram/messages.csv')\n",
+    "CLEAN_CSV = os.getenv('CLEAN_CSV', '/content/drive/MyDrive/telegram/cleaned.csv')\n",
+    "SESSION_NAME = os.getenv('SESSION_NAME', 'tg_session')"
    ],
    "metadata": {
     "id": "ykINbo9OxNpF"


### PR DESCRIPTION
## Summary
- let the notebook pick up `PROGRESS_JSON`, `RAW_CSV` and `CLEAN_CSV` from the environment
- note that path variables are optional in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*