### PR TITLE
Stop running main() in notebook

### DIFF
--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -630,7 +630,7 @@
   {
    "cell_type": "code",
    "source": [
-    "main()"
+    "# main()"
    ],
    "metadata": {
     "id": "OGndW8SXFPkE"


### PR DESCRIPTION
## Summary
- avoid running main() when the notebook executes all cells
- leave main() defined for manual invocation

## Testing
- `API_ID=1 API_HASH=hash PHONE=ph TS_SKIP_DATASET=1 python3 -m unittest discover -v tests`