### PR TITLE
Add BFS filtering and hard-coded creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Telegram-research
+
+The notebook contains hard-coded credentials for the Telegram API.
+Update the `API_ID`, `API_HASH`, and `PHONE` variables in the first code cell with
+your own values before running it.

--- a/Telegram (5).ipynb
+++ b/Telegram (5).ipynb
@@ -1,720 +1,761 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "provenance": [],
-   "machine_shape": "hm"
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/"
+      "provenance": [],
+      "machine_shape": "hm"
     },
-    "id": "hBowC3JUyXcy",
-    "outputId": "edb3d59c-4515-42e5-ae64-83fd081e2fd0"
-   },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Requirement already satisfied: telethon in /usr/local/lib/python3.11/dist-packages (1.40.0)\n",
-      "Requirement already satisfied: pandas in /usr/local/lib/python3.11/dist-packages (2.2.2)\n",
-      "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (2.32.3)\n",
-      "Requirement already satisfied: langdetect in /usr/local/lib/python3.11/dist-packages (1.0.9)\n",
-      "Requirement already satisfied: pyaes in /usr/local/lib/python3.11/dist-packages (from telethon) (1.6.1)\n",
-      "Requirement already satisfied: rsa in /usr/local/lib/python3.11/dist-packages (from telethon) (4.9.1)\n",
-      "Requirement already satisfied: numpy>=1.23.2 in /usr/local/lib/python3.11/dist-packages (from pandas) (2.0.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.11/dist-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas) (2025.2)\n",
-      "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas) (2025.2)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests) (3.4.1)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests) (3.10)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests) (2.4.0)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests) (2025.4.26)\n",
-      "Requirement already satisfied: six in /usr/local/lib/python3.11/dist-packages (from langdetect) (1.17.0)\n",
-      "Requirement already satisfied: pyasn1>=0.1.3 in /usr/local/lib/python3.11/dist-packages (from rsa->telethon) (0.6.1)\n"
-     ]
-    }
-   ],
-   "source": [
-    "pip install telethon pandas requests langdetect\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "pip install python-dotenv"
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     },
-    "id": "FMPetDnuEL_a",
-    "outputId": "bb13a890-d08c-4ba5-bcdc-9c2cd5ed6344"
-   },
-   "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Requirement already satisfied: python-dotenv in /usr/local/lib/python3.11/dist-packages (1.1.0)\n"
-     ]
+    "language_info": {
+      "name": "python"
     }
-   ]
   },
-  {
-   "cell_type": "code",
-   "source": [
-    "pip install nest_asyncio"
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hBowC3JUyXcy",
+        "outputId": "edb3d59c-4515-42e5-ae64-83fd081e2fd0"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: telethon in /usr/local/lib/python3.11/dist-packages (1.40.0)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.11/dist-packages (2.2.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (2.32.3)\n",
+            "Requirement already satisfied: langdetect in /usr/local/lib/python3.11/dist-packages (1.0.9)\n",
+            "Requirement already satisfied: pyaes in /usr/local/lib/python3.11/dist-packages (from telethon) (1.6.1)\n",
+            "Requirement already satisfied: rsa in /usr/local/lib/python3.11/dist-packages (from telethon) (4.9.1)\n",
+            "Requirement already satisfied: numpy>=1.23.2 in /usr/local/lib/python3.11/dist-packages (from pandas) (2.0.2)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.11/dist-packages (from pandas) (2.9.0.post0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas) (2025.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests) (3.4.1)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests) (2.4.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests) (2025.4.26)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.11/dist-packages (from langdetect) (1.17.0)\n",
+            "Requirement already satisfied: pyasn1>=0.1.3 in /usr/local/lib/python3.11/dist-packages (from rsa->telethon) (0.6.1)\n"
+          ]
+        }
+      ],
+      "source": [
+        "pip install telethon pandas requests langdetect\n"
+      ]
     },
-    "id": "VFIAy13PHt80",
-    "outputId": "41d84001-1d7e-4a59-ab43-a68e3f86f5b7"
-   },
-   "execution_count": null,
-   "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Requirement already satisfied: nest_asyncio in /usr/local/lib/python3.11/dist-packages (1.6.0)\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
-   ],
-   "metadata": {
-    "id": "QXdS3FUDHvyt"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "import os, json, csv, time, re\n",
-    "import csv, json\n",
-    "import asyncio, requests, pandas as pd\n",
-    "from pathlib import Path\n",
-    "from dotenv import load_dotenv\n",
-    "from urllib.parse import urlparse\n",
-    "from langdetect import detect, DetectorFactory\n",
-    "DetectorFactory.seed=0"
-   ],
-   "metadata": {
-    "id": "Cf2Q2pXXC4ZM"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from telethon import TelegramClient, errors\n",
-    "from telethon.tl.functions.channels import JoinChannelRequest\n",
-    "from telethon.tl.types import PeerChannel"
-   ],
-   "metadata": {
-    "id": "oGRmc41x_UlG"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from telethon.sync import TelegramClient\n",
-    "from getpass import getpass"
-   ],
-   "metadata": {
-    "id": "OMcGFBPF_UoF"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from telethon import TelegramClient, errors\n",
-    "from telethon.tl.functions.channels import JoinChannelRequest\n",
-    "API_ID=24527187;API_HASH='8a012769064c0218d779c9e23e45fdb0';PHONE='+18573343025'\n"
-   ],
-   "metadata": {
-    "id": "_MchyQTGC8IQ"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "channels_df = pd.read_csv('telegram_misinformation_channels_full.csv')\n",
-    "def _parse_subs(s):\n",
-    "    s = str(s).replace('+', '').strip()\n",
-    "    mult = 1\n",
-    "    if s.lower().endswith('k'):\n",
-    "        mult = 1000\n",
-    "        s = s[:-1]\n",
-    "    elif s.lower().endswith('m'):\n",
-    "        mult = 1000000\n",
-    "        s = s[:-1]\n",
-    "    try:\n",
-    "        return int(float(s) * mult)\n",
-    "    except ValueError:\n",
-    "        return 0\n",
-    "channels_df['subs_num'] = channels_df['Subscribers'].apply(_parse_subs)\n",
-    "seed_usernames = channels_df['Username'].tolist()\n",
-    "FOLLOWERS_DICT = channels_df.set_index('Username')['subs_num'].to_dict()"
-   ],
-   "metadata": {
-    "id": "ba2Vaw21xPEj"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "CHANNELS = seed_usernames"
-   ],
-   "metadata": {
-    "id": "zIi_m0JbdyX5"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "# Load existing progress data (if any) and merge new seeds with value 0\n",
-    "try:\n",
-    "    with open('progress.json', 'r') as pf:\n",
-    "        progress = json.load(pf)\n",
-    "except FileNotFoundError:\n",
-    "    progress = {}\n",
-    "for username in seed_usernames:\n",
-    "    if username not in progress:\n",
-    "        progress[username] = 0  # mark as not yet scraped"
-   ],
-   "metadata": {
-    "id": "Ir_L4HSPdya5"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "# Save the updated progress mapping back to file\n",
-    "with open('progress.json', 'w') as pf:\n",
-    "    json.dump(progress, pf)"
-   ],
-   "metadata": {
-    "id": "qocb8QV2dyg3"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from google.colab import drive\n",
-    "drive.mount('/content/drive', force_remount=True)"
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
+      "cell_type": "code",
+      "source": [
+        "pip install python-dotenv"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "FMPetDnuEL_a",
+        "outputId": "bb13a890-d08c-4ba5-bcdc-9c2cd5ed6344"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: python-dotenv in /usr/local/lib/python3.11/dist-packages (1.1.0)\n"
+          ]
+        }
+      ]
     },
-    "id": "rRnvbW8UdykJ",
-    "outputId": "f192320a-f469-4640-b498-8b16e23a1324"
-   },
-   "execution_count": null,
-   "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Mounted at /content/drive\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "PROGRESS_JSON='/content/drive/MyDrive/telegram/progress.json'\n",
-    "RAW_CSV='/content/drive/MyDrive/telegram/messages.csv'\n",
-    "CLEAN_CSV='/content/drive/MyDrive/telegram/cleaned.csv'\n",
-    "SESSION_NAME='tg_session'"
-   ],
-   "metadata": {
-    "id": "ykINbo9OxNpF"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "7dYlGjV_INa4"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "client=TelegramClient(SESSION_NAME,API_ID,API_HASH)\n",
-    "def load_progress():\n",
-    "  if os.path.exists(PROGRESS_JSON):\n",
-    "    with open(PROGRESS_JSON,'r')as f:return json.load(f)\n",
-    "  return {}\n"
-   ],
-   "metadata": {
-    "id": "Bdu3oFp__UrI"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def save_progress(d):\n",
-    "  os.makedirs(os.path.dirname(PROGRESS_JSON),exist_ok=True)\n",
-    "  with open(PROGRESS_JSON,'w')as f:json.dump(d,f)\n",
-    "  print(\"Progress saved.\")\n"
-   ],
-   "metadata": {
-    "id": "XlaWF6Z0AY6-"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def append_header_if_needed():\n",
-    "  ex=os.path.exists(RAW_CSV)\n",
-    "  os.makedirs(os.path.dirname(RAW_CSV),exist_ok=True)\n",
-    "  if not ex:\n",
-    "    with open(RAW_CSV,'w',newline='',encoding='utf-8')as f:\n",
-    "      csv.writer(f).writerow(['channel','msg_id','date','text','fwd_from','fwd_id'])\n"
-   ],
-   "metadata": {
-    "id": "4nOQuxbgAY8k"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def join_if_needed(ent):\n",
-    "  if getattr(ent,'megagroup',False):\n",
-    "    try:await client(JoinChannelRequest(ent))\n",
-    "    except:pass\n"
-   ],
-   "metadata": {
-    "id": "HoqHVl86E-_U"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def scrape_channel(name,last_id):\n",
-    "  try:ent=await client.get_entity(name)\n",
-    "  except Exception as e:print(\"Skip\",name,e);return last_id\n",
-    "  await join_if_needed(ent);mx=last_id;cnt=0\n",
-    "  async for msg in client.iter_messages(ent,min_id=last_id,reverse=False):\n",
-    "    cnt+=1;mx=max(mx,msg.id);fw,fwid=None,None\n",
-    "    if msg.forward:\n",
-    "      if msg.forward.chat:fw=msg.forward.chat.title or msg.forward.chat.username;fwid=getattr(msg.forward.chat,'id',None)\n",
-    "      elif msg.forward.sender:fw=msg.forward.sender.first_name or msg.forward.sender.username or'Private';fwid=getattr(msg.forward.sender,'id',None)\n",
-    "    with open(RAW_CSV,'a',newline='',encoding='utf-8')as f:\n",
-    "      csv.writer(f).writerow([name,msg.id,msg.date,msg.text or'',fw,fwid])\n",
-    "  print(name,\"+%d msgs\"%cnt,\"up to\",mx);return mx\n"
-   ],
-   "metadata": {
-    "id": "5pQiuvbeE_Ax"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def scrape_once():\n",
-    "  await client.start(phone=PHONE)\n",
-    "  last_seen=load_progress();append_header_if_needed()\n",
-    "  for c in CHANNELS:\n",
-    "    sid=last_seen.get(c,0)\n",
-    "    new_id=await scrape_channel(c,sid)\n",
-    "    last_seen[c]=new_id\n",
-    "  save_progress(last_seen);await client.disconnect()\n"
-   ],
-   "metadata": {
-    "id": "w7JNJcbwE_EY"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def run_scrape():\n",
-    "  asyncio.run(scrape_once())\n",
-    "  print(\"Scraping done.\")\n"
-   ],
-   "metadata": {
-    "id": "Fk_TBzdwE_G9"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def deduplicate(messages):\n",
-    "  out=[];seen=set()\n",
-    "  for m in messages:\n",
-    "    k=(m.get('fwd_id'),m.get('text'))\n",
-    "    if m.get('fwd_id'):\n",
-    "      if k in seen:continue\n",
-    "      seen.add(k)\n",
-    "    out.append(m)\n",
-    "  return out\n"
-   ],
-   "metadata": {
-    "id": "EWBJBeXIE_Jy"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def unshorten_url(u,t=5):\n",
-    "  try:return requests.head(u,allow_redirects=True,timeout=t).url\n",
-    "  except:return u\n"
-   ],
-   "metadata": {
-    "id": "s2kMEf60E_MH"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def expand_and_extract(m):\n",
-    "  txt=m['text'];urls=re.findall(r'https?://\\S+',txt)\n",
-    "  dom=set()\n",
-    "  for u in urls:\n",
-    "    fin=unshorten_url(u);d=urlparse(fin).netloc\n",
-    "    dom.add(d)\n",
-    "    txt=txt.replace(u,fin)\n",
-    "  m['text']=txt;m['domains']=list(dom);return m\n"
-   ],
-   "metadata": {
-    "id": "5S7R0ES3E_O1"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def is_english(txt):\n",
-    "  if not txt.strip():return False\n",
-    "  try:return(detect(txt)=='en')\n",
-    "  except:return False\n"
-   ],
-   "metadata": {
-    "id": "aFUAEBWiE_TT"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def anonymize(m,user_map):\n",
-    "  if m.get('fwd_id')and m['fwd_from']and not str(m['fwd_from']).startswith(('Channel','@')):\n",
-    "    if m['fwd_id'] not in user_map:user_map[m['fwd_id']]=f\"User{len(user_map)+1}\"\n",
-    "    m['fwd_from']=user_map[m['fwd_id']];m['fwd_id']=None\n",
-    "  m['text']=re.sub(r'@[\\w\\d_]+','@USER',m['text'])\n",
-    "  return m\n"
-   ],
-   "metadata": {
-    "id": "xvy8iJ-HE_Vn"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def preprocess_data():\n",
-    "  if not os.path.exists(RAW_CSV):print(\"No raw CSV.\");return\n",
-    "  df=pd.read_csv(RAW_CSV,names=['chan','msg_id','date','text','fwd_from','fwd_id'],header=0)\n",
-    "  msgs=df.to_dict('records');msgs=deduplicate(msgs)\n",
-    "  out=[];umap={}\n",
-    "  for m in msgs:\n",
-    "    m=expand_and_extract(m)\n",
-    "    if is_english(m['text']):m=anonymize(m,umap);out.append(m)\n",
-    "  pd.DataFrame(out).to_csv(CLEAN_CSV,index=False)\n",
-    "  print(f\"Saved {len(out)} cleaned msgs to {CLEAN_CSV}\")\n"
-   ],
-   "metadata": {
-    "id": "XuQE2tRRFPeo"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "BFS_HOPS         = 2     # how many BFS layers\n",
-    "BFS_PER_CH_LIMIT = 400   # how many msgs to scan for forwards each discovered channel\n",
-    "BFS_MIN_SUBS     = 500   # subscriber threshold\n",
-    "BFS_LANG_SAMPLE  = 15    # how many msgs we sample for English\n",
-    "BFS_EN_RATIO     = 0.5   # 50% must be English"
-   ],
-   "metadata": {
-    "id": "YYpOd88Gv4Mg"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from langdetect import detect\n",
-    "async def _en_ratio(ent, sample=BFS_LANG_SAMPLE):\n",
-    "    en = 0\n",
-    "    async for m in client.iter_messages(ent, limit=sample):\n",
-    "        t = (m.message or '').strip()\n",
-    "        if t:\n",
-    "            try:  en += detect(t)=='en'\n",
-    "            except: pass\n",
-    "    return 0 if not sample else en/sample\n"
-   ],
-   "metadata": {
-    "id": "h8KS4Vdgv4Pu"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "from telethon.tl.types import PeerChannel\n",
-    "async def _forward_sources(ent, limit=BFS_PER_CH_LIMIT):\n",
-    "    src = set()\n",
-    "    async for m in client.iter_messages(ent, limit=limit):\n",
-    "        fwd = m.forward\n",
-    "        if not fwd: continue\n",
-    "        pc  = fwd.chat or fwd.original_fwd\n",
-    "        if isinstance(pc, PeerChannel): src.add(pc.channel_id)\n",
-    "    return src\n"
-   ],
-   "metadata": {
-    "id": "d5gZoB5XwXYm"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def _is_valid(ent):\n",
-    "    \"\"\"\n",
-    "    Check if a Telegram entity meets minimum subscriber and English-ratio criteria.\n",
-    "    It uses CSV's `Subscribers` column as the primary subscriber count.\n",
-    "    \"\"\"\n",
-    "    username = (getattr(ent, 'username', '') or '').strip()\n",
-    "\n",
-    "    # Fetch subscriber count directly from CSV, defaulting to 0 if not found\n",
-    "    count = FOLLOWERS_DICT.get(username, 0)\n",
-    "\n",
-    "    if count < BFS_MIN_SUBS:\n",
-    "        return False\n",
-    "\n",
-    "    # Check English language ratio\n",
-    "    try:\n",
-    "        return (await _en_ratio(ent)) >= BFS_EN_RATIO\n",
-    "    except Exception:\n",
-    "        return False\n"
-   ],
-   "metadata": {
-    "id": "eFK9klEFwXbm",
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 228
+      "cell_type": "code",
+      "source": [
+        "pip install nest_asyncio"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VFIAy13PHt80",
+        "outputId": "41d84001-1d7e-4a59-ab43-a68e3f86f5b7"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: nest_asyncio in /usr/local/lib/python3.11/dist-packages (1.6.0)\n"
+          ]
+        }
+      ]
     },
-    "outputId": "f6a4f455-e91c-4f60-9956-8dd45ba63c5f"
-   },
-   "execution_count": null,
-   "outputs": [
     {
-     "output_type": "error",
-     "ename": "NameError",
-     "evalue": "name 'df_updated' is not defined",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-101-8c24220e39ce>\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Create followers lookup dictionary (execute once after loading CSV)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mFOLLOWERS_DICT\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdf_updated\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'channel'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'followers'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mapply\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_numeric\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merrors\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'coerce'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfillna\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_dict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32masync\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0m_is_valid\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \"\"\"\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'df_updated' is not defined"
-     ]
+      "cell_type": "code",
+      "source": [
+        "import nest_asyncio\n",
+        "nest_asyncio.apply()"
+      ],
+      "metadata": {
+        "id": "QXdS3FUDHvyt"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os, json, csv, time, re\n",
+        "import csv, json\n",
+        "import asyncio, requests, pandas as pd\n",
+        "from pathlib import Path\n",
+        "from urllib.parse import urlparse\n",
+        "from langdetect import detect, DetectorFactory\n",
+        "from datetime import datetime\n",
+        "DetectorFactory.seed=0\n"
+      ],
+      "metadata": {
+        "id": "Cf2Q2pXXC4ZM"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from telethon import TelegramClient, errors\n",
+        "from telethon.tl.functions.channels import JoinChannelRequest, GetFullChannelRequest\n",
+        "from telethon.tl.types import PeerChannel"
+      ],
+      "metadata": {
+        "id": "oGRmc41x_UlG"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from telethon.sync import TelegramClient\n",
+        "from getpass import getpass"
+      ],
+      "metadata": {
+        "id": "OMcGFBPF_UoF"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from telethon import TelegramClient, errors\n",
+        "from telethon.tl.functions.channels import JoinChannelRequest\n",
+        "# Hard-coded Telegram credentials. Replace with your own.\n",
+        "API_ID = 123456\n",
+        "API_HASH = 'your_api_hash'\n",
+        "PHONE = '+10000000000'\n"
+      ],
+      "metadata": {
+        "id": "_MchyQTGC8IQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "channels_df = pd.read_csv('telegram_misinformation_channels_full.csv')\n",
+        "def _parse_subs(s):\n",
+        "    s = str(s).replace('+', '').strip()\n",
+        "    mult = 1\n",
+        "    if s.lower().endswith('k'):\n",
+        "        mult = 1000\n",
+        "        s = s[:-1]\n",
+        "    elif s.lower().endswith('m'):\n",
+        "        mult = 1000000\n",
+        "        s = s[:-1]\n",
+        "    try:\n",
+        "        return int(float(s) * mult)\n",
+        "    except ValueError:\n",
+        "        return 0\n",
+        "channels_df['subs_num'] = channels_df['Subscribers'].apply(_parse_subs)\n",
+        "seed_usernames = channels_df['Username'].tolist()\n",
+        "FOLLOWERS_DICT = channels_df.set_index('Username')['subs_num'].to_dict()"
+      ],
+      "metadata": {
+        "id": "ba2Vaw21xPEj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "CHANNELS = seed_usernames"
+      ],
+      "metadata": {
+        "id": "zIi_m0JbdyX5"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Load existing progress data (if any) and merge new seeds with value 0\n",
+        "try:\n",
+        "    with open('progress.json', 'r') as pf:\n",
+        "        progress = json.load(pf)\n",
+        "except FileNotFoundError:\n",
+        "    progress = {}\n",
+        "for username in seed_usernames:\n",
+        "    if username not in progress:\n",
+        "        progress[username] = 0  # mark as not yet scraped"
+      ],
+      "metadata": {
+        "id": "Ir_L4HSPdya5"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Save the updated progress mapping back to file\n",
+        "with open('progress.json', 'w') as pf:\n",
+        "    json.dump(progress, pf)"
+      ],
+      "metadata": {
+        "id": "qocb8QV2dyg3"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive', force_remount=True)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "rRnvbW8UdykJ",
+        "outputId": "f192320a-f469-4640-b498-8b16e23a1324"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Mounted at /content/drive\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "PROGRESS_JSON='/content/drive/MyDrive/telegram/progress.json'\n",
+        "RAW_CSV='/content/drive/MyDrive/telegram/messages.csv'\n",
+        "CLEAN_CSV='/content/drive/MyDrive/telegram/cleaned.csv'\n",
+        "SESSION_NAME='tg_session'"
+      ],
+      "metadata": {
+        "id": "ykINbo9OxNpF"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "7dYlGjV_INa4"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "client=TelegramClient(SESSION_NAME,API_ID,API_HASH)\n",
+        "def load_progress():\n",
+        "  if os.path.exists(PROGRESS_JSON):\n",
+        "    with open(PROGRESS_JSON,'r')as f:return json.load(f)\n",
+        "  return {}\n"
+      ],
+      "metadata": {
+        "id": "Bdu3oFp__UrI"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def save_progress(d):\n",
+        "  os.makedirs(os.path.dirname(PROGRESS_JSON),exist_ok=True)\n",
+        "  with open(PROGRESS_JSON,'w')as f:json.dump(d,f)\n",
+        "  print(\"Progress saved.\")\n"
+      ],
+      "metadata": {
+        "id": "XlaWF6Z0AY6-"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def append_header_if_needed():\n",
+        "  ex=os.path.exists(RAW_CSV)\n",
+        "  os.makedirs(os.path.dirname(RAW_CSV),exist_ok=True)\n",
+        "  if not ex:\n",
+        "    with open(RAW_CSV,'w',newline='',encoding='utf-8')as f:\n",
+        "      csv.writer(f).writerow(['channel','msg_id','date','text','fwd_from','fwd_id'])\n"
+      ],
+      "metadata": {
+        "id": "4nOQuxbgAY8k"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def join_if_needed(ent):\n",
+        "  if getattr(ent,'megagroup',False):\n",
+        "    try:await client(JoinChannelRequest(ent))\n",
+        "    except:pass\n"
+      ],
+      "metadata": {
+        "id": "HoqHVl86E-_U"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def scrape_channel(name,last_id):\n",
+        "  try:ent=await client.get_entity(name)\n",
+        "  except Exception as e:print(\"Skip\",name,e);return last_id\n",
+        "  await join_if_needed(ent);mx=last_id;cnt=0\n",
+        "  async for msg in client.iter_messages(ent,min_id=last_id,reverse=False):\n",
+        "    cnt+=1;mx=max(mx,msg.id);fw,fwid=None,None\n",
+        "    if msg.forward:\n",
+        "      if msg.forward.chat:fw=msg.forward.chat.title or msg.forward.chat.username;fwid=getattr(msg.forward.chat,'id',None)\n",
+        "      elif msg.forward.sender:fw=msg.forward.sender.first_name or msg.forward.sender.username or'Private';fwid=getattr(msg.forward.sender,'id',None)\n",
+        "    with open(RAW_CSV,'a',newline='',encoding='utf-8')as f:\n",
+        "      csv.writer(f).writerow([name,msg.id,msg.date,msg.text or'',fw,fwid])\n",
+        "  print(name,\"+%d msgs\"%cnt,\"up to\",mx);return mx\n"
+      ],
+      "metadata": {
+        "id": "5pQiuvbeE_Ax"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def scrape_once():\n",
+        "  await client.start(phone=PHONE)\n",
+        "  last_seen=load_progress();append_header_if_needed()\n",
+        "  for c in CHANNELS:\n",
+        "    sid=last_seen.get(c,0)\n",
+        "    new_id=await scrape_channel(c,sid)\n",
+        "    last_seen[c]=new_id\n",
+        "  save_progress(last_seen);await client.disconnect()\n"
+      ],
+      "metadata": {
+        "id": "w7JNJcbwE_EY"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def run_scrape():\n",
+        "  asyncio.run(scrape_once())\n",
+        "  print(\"Scraping done.\")\n"
+      ],
+      "metadata": {
+        "id": "Fk_TBzdwE_G9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def deduplicate(messages):\n",
+        "  out=[];seen=set()\n",
+        "  for m in messages:\n",
+        "    k=(m.get('fwd_id'),m.get('text'))\n",
+        "    if m.get('fwd_id'):\n",
+        "      if k in seen:continue\n",
+        "      seen.add(k)\n",
+        "    out.append(m)\n",
+        "  return out\n"
+      ],
+      "metadata": {
+        "id": "EWBJBeXIE_Jy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def unshorten_url(u,t=5):\n",
+        "  try:return requests.head(u,allow_redirects=True,timeout=t).url\n",
+        "  except:return u\n"
+      ],
+      "metadata": {
+        "id": "s2kMEf60E_MH"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def expand_and_extract(m):\n",
+        "  txt=m['text'];urls=re.findall(r'https?://\\S+',txt)\n",
+        "  dom=set()\n",
+        "  for u in urls:\n",
+        "    fin=unshorten_url(u);d=urlparse(fin).netloc\n",
+        "    dom.add(d)\n",
+        "    txt=txt.replace(u,fin)\n",
+        "  m['text']=txt;m['domains']=list(dom);return m\n"
+      ],
+      "metadata": {
+        "id": "5S7R0ES3E_O1"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def is_english(txt):\n",
+        "  if not txt.strip():return False\n",
+        "  try:return(detect(txt)=='en')\n",
+        "  except:return False\n"
+      ],
+      "metadata": {
+        "id": "aFUAEBWiE_TT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def anonymize(m,user_map):\n",
+        "  if m.get('fwd_id')and m['fwd_from']and not str(m['fwd_from']).startswith(('Channel','@')):\n",
+        "    if m['fwd_id'] not in user_map:user_map[m['fwd_id']]=f\"User{len(user_map)+1}\"\n",
+        "    m['fwd_from']=user_map[m['fwd_id']];m['fwd_id']=None\n",
+        "  m['text']=re.sub(r'@[\\w\\d_]+','@USER',m['text'])\n",
+        "  return m\n"
+      ],
+      "metadata": {
+        "id": "xvy8iJ-HE_Vn"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def preprocess_data():\n",
+        "  if not os.path.exists(RAW_CSV):print(\"No raw CSV.\");return\n",
+        "  df=pd.read_csv(RAW_CSV,names=['chan','msg_id','date','text','fwd_from','fwd_id'],header=0)\n",
+        "  msgs=df.to_dict('records');msgs=deduplicate(msgs)\n",
+        "  out=[];umap={}\n",
+        "  for m in msgs:\n",
+        "    m=expand_and_extract(m)\n",
+        "    if is_english(m['text']):m=anonymize(m,umap);out.append(m)\n",
+        "  pd.DataFrame(out).to_csv(CLEAN_CSV,index=False)\n",
+        "  print(f\"Saved {len(out)} cleaned msgs to {CLEAN_CSV}\")\n"
+      ],
+      "metadata": {
+        "id": "XuQE2tRRFPeo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "BFS_HOPS         = 2     # how many BFS layers\n",
+        "BFS_PER_CH_LIMIT = 400   # how many msgs to scan for forwards each discovered channel\n",
+        "BFS_MIN_SUBS     = 500   # subscriber threshold\n",
+        "BFS_LANG_SAMPLE  = 15    # how many msgs we sample for English\n",
+        "BFS_EN_RATIO     = 0.5   # 50% must be English\n",
+        "BFS_FWD_MIN      = 1     # forwards needed to consider a source\n",
+        "BFS_INCLUDE_MENTIONS = False  # crawl @mentions as well\n",
+        "BFS_TOPIC_KEYWORDS = []  # keywords for topic filtering\n",
+        "BFS_TOPIC_RATIO  = 0.0   # fraction of msgs needing keywords\n",
+        "BFS_TOPIC_SAMPLE = 15    # msgs to sample for topic check\n",
+        "BFS_MAX_DORMANT_DAYS = 0 # skip channels inactive this many days"
+      ],
+      "metadata": {
+        "id": "YYpOd88Gv4Mg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from langdetect import detect\n",
+        "async def _en_ratio(ent, sample=BFS_LANG_SAMPLE):\n",
+        "    en = 0\n",
+        "    async for m in client.iter_messages(ent, limit=sample):\n",
+        "        t = (m.message or '').strip()\n",
+        "        if t:\n",
+        "            try:  en += detect(t)=='en'\n",
+        "            except: pass\n",
+        "    return 0 if not sample else en/sample\n"
+      ],
+      "metadata": {
+        "id": "h8KS4Vdgv4Pu"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from telethon.tl.types import PeerChannel\n",
+        "async def _forward_sources(ent, limit=BFS_PER_CH_LIMIT):\n",
+        "    counts = {}\n",
+        "    async for m in client.iter_messages(ent, limit=limit):\n",
+        "        fwd = m.forward\n",
+        "        if not fwd:\n",
+        "            continue\n",
+        "        pc = fwd.chat or fwd.original_fwd\n",
+        "        if isinstance(pc, PeerChannel):\n",
+        "            cid = pc.channel_id\n",
+        "            counts[cid] = counts.get(cid, 0) + 1\n",
+        "    return {cid for cid, cnt in counts.items() if cnt >= BFS_FWD_MIN}\n"
+      ],
+      "metadata": {
+        "id": "d5gZoB5XwXYm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def _mention_sources(ent, limit=BFS_PER_CH_LIMIT):\n",
+        "    pattern = re.compile(r'(?:@|t.me/)([A-Za-z0-9_]{5,})')\n",
+        "    found = set()\n",
+        "    async for m in client.iter_messages(ent, limit=limit):\n",
+        "        txt = m.message or ''\n",
+        "        for u in pattern.findall(txt):\n",
+        "            found.add(u.lstrip('@'))\n",
+        "    return found\n"
+      ],
+      "metadata": {
+        "id": "mentioncell"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def _is_valid(ent):\n",
+        "    username = (getattr(ent, 'username', '') or '').strip()\n",
+        "    count = FOLLOWERS_DICT.get(username, 0)\n",
+        "    if count == 0:\n",
+        "        try:\n",
+        "            full = await client(GetFullChannelRequest(ent))\n",
+        "            count = getattr(full.full_chat, 'participants_count', 0) or 0\n",
+        "        except Exception:\n",
+        "            count = 0\n",
+        "    if count < BFS_MIN_SUBS:\n",
+        "        return False\n",
+        "    try:\n",
+        "        if (await _en_ratio(ent)) < BFS_EN_RATIO:\n",
+        "            return False\n",
+        "    except Exception:\n",
+        "        return False\n",
+        "    if BFS_TOPIC_KEYWORDS:\n",
+        "        hits = 0\n",
+        "        async for m in client.iter_messages(ent, limit=BFS_TOPIC_SAMPLE):\n",
+        "            text = (m.message or '').lower()\n",
+        "            if any(k.lower() in text for k in BFS_TOPIC_KEYWORDS):\n",
+        "                hits += 1\n",
+        "        ratio = hits / BFS_TOPIC_SAMPLE if BFS_TOPIC_SAMPLE else 0\n",
+        "        if BFS_TOPIC_RATIO > 0:\n",
+        "            if ratio < BFS_TOPIC_RATIO:\n",
+        "                return False\n",
+        "        elif hits == 0:\n",
+        "            return False\n",
+        "    if BFS_MAX_DORMANT_DAYS > 0:\n",
+        "        msgs = [m async for m in client.iter_messages(ent, limit=1)]\n",
+        "        if not msgs:\n",
+        "            return False\n",
+        "        last_date = msgs[0].date.replace(tzinfo=None)\n",
+        "        if (datetime.utcnow() - last_date).days > BFS_MAX_DORMANT_DAYS:\n",
+        "            return False\n",
+        "    return True\n"
+      ],
+      "metadata": {
+        "id": "eFK9klEFwXbm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def snowball_discovery():\n",
+        "    global CHANNELS\n",
+        "    prog = load_progress()\n",
+        "    seeds = [c.lstrip('@') for c in CHANNELS]\n",
+        "    frontier = set(seeds)\n",
+        "    visited = set(seeds) | set(prog.keys())\n",
+        "    validated = []\n",
+        "    for hop in range(1, BFS_HOPS+1):\n",
+        "        nxt = set()\n",
+        "        print(f'\u00b7 hop {hop}  frontier={len(frontier)}')\n",
+        "        for h in list(frontier):\n",
+        "            try: ent = await client.get_entity(h)\n",
+        "            except: continue\n",
+        "            if not await _is_valid(ent): continue\n",
+        "            validated.append(h)\n",
+        "            new_names = set()\n",
+        "            for cid in await _forward_sources(ent):\n",
+        "                try:\n",
+        "                    e = await client.get_entity(PeerChannel(cid))\n",
+        "                    if e.username:\n",
+        "                        new_names.add(e.username)\n",
+        "                except:\n",
+        "                    pass\n",
+        "            if BFS_INCLUDE_MENTIONS:\n",
+        "                new_names |= await _mention_sources(ent)\n",
+        "            for uname in new_names:\n",
+        "                if uname not in visited:\n",
+        "                    visited.add(uname)\n",
+        "                    nxt.add(uname)\n",
+        "        frontier = nxt\n",
+        "    for v in validated:\n",
+        "        if v not in prog: prog[v] = 0\n",
+        "    save_progress(prog)\n",
+        "    globals()['CHANNELS'] = list(set(CHANNELS) | set(prog))\n",
+        "    print('validated:', len(validated), ' | total CHANNELS:', len(CHANNELS))\n"
+      ],
+      "metadata": {
+        "id": "wjHw18VOwXeS"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "async def scrape_once():\n",
+        "    await client.start(phone=PHONE)\n",
+        "    await snowball_discovery()          # ①  discover / merge\n",
+        "    last = load_progress(); append_header_if_needed()\n",
+        "    for c in CHANNELS:\n",
+        "        last[c] = await scrape_channel(c, last.get(c,0))\n",
+        "    save_progress(last); await client.disconnect()\n"
+      ],
+      "metadata": {
+        "id": "zOHfC_v0wXg5"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "72V3QfqtwXrU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def main():\n",
+        "  run_scrape()\n",
+        "  preprocess_data()\n",
+        "  print(\"Done.\")\n"
+      ],
+      "metadata": {
+        "id": "Ly3Z1jugFPhg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "main()"
+      ],
+      "metadata": {
+        "id": "OGndW8SXFPkE"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "h-yHan5eIOXU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "t2BV4RqMFPnC"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "gPzbPg2FFPpk"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "cNaiQjMnE_YT"
+      },
+      "execution_count": null,
+      "outputs": []
     }
-   ]
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def snowball_discovery():\n",
-    "    global CHANNELS\n",
-    "    prog, seeds = load_progress(), [c.lstrip('@') for c in CHANNELS]\n",
-    "    frontier, visited, validated = set(seeds), set(seeds), []\n",
-    "\n",
-    "    for hop in range(1, BFS_HOPS+1):\n",
-    "        nxt = set()\n",
-    "        print(f'\u00b7 hop {hop}  frontier={len(frontier)}')\n",
-    "        for h in list(frontier):\n",
-    "            try: ent = await client.get_entity(h)\n",
-    "            except: continue\n",
-    "            if not await _is_valid(ent): continue\n",
-    "            validated.append(h)\n",
-    "            for cid in await _forward_sources(ent):\n",
-    "                try:\n",
-    "                    e = await client.get_entity(PeerChannel(cid))\n",
-    "                    if e.username and e.username not in visited:\n",
-    "                        visited.add(e.username); nxt.add(e.username)\n",
-    "                except: pass\n",
-    "        frontier = nxt\n",
-    "    for v in validated:\n",
-    "        if v not in prog: prog[v] = 0\n",
-    "    save_progress(prog)\n",
-    "    globals()['CHANNELS'] = list(set(CHANNELS)|set(prog))\n",
-    "    print('validated:',len(validated),' | total CHANNELS:',len(CHANNELS))\n"
-   ],
-   "metadata": {
-    "id": "wjHw18VOwXeS"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "async def scrape_once():\n",
-    "    await client.start(phone=PHONE)\n",
-    "    await snowball_discovery()          # \u2460  discover / merge\n",
-    "    last = load_progress(); append_header_if_needed()\n",
-    "    for c in CHANNELS:\n",
-    "        last[c] = await scrape_channel(c, last.get(c,0))\n",
-    "    save_progress(last); await client.disconnect()\n"
-   ],
-   "metadata": {
-    "id": "zOHfC_v0wXg5"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "72V3QfqtwXrU"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "def main():\n",
-    "  run_scrape()\n",
-    "  preprocess_data()\n",
-    "  print(\"Done.\")\n"
-   ],
-   "metadata": {
-    "id": "Ly3Z1jugFPhg"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "main()"
-   ],
-   "metadata": {
-    "id": "OGndW8SXFPkE"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "h-yHan5eIOXU"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "t2BV4RqMFPnC"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "gPzbPg2FFPpk"
-   },
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": [],
-   "metadata": {
-    "id": "cNaiQjMnE_YT"
-   },
-   "execution_count": null,
-   "outputs": []
-  }
- ]
+  ]
 }


### PR DESCRIPTION
## Summary
- switch back to hard-coded Telegram credentials
- implement mention-based discovery and forward count threshold
- add topic and dormancy filters in validation logic
- document that credentials are hard coded

## Testing
- `python3 -m json.tool 'Telegram (5).ipynb'`
- `grep -n BFS_FWD_MIN -n 'Telegram (5).ipynb'`
